### PR TITLE
Добавить двусвязный список в InMemoryHistoryManager и методы взаимодействия с ним

### DIFF
--- a/src/ru/practicum/manager/HistoryManager.java
+++ b/src/ru/practicum/manager/HistoryManager.java
@@ -9,4 +9,6 @@ public interface HistoryManager {
     void add(Task task);
 
     List<Task> getHistory();
+
+    void remove(int id);
 }

--- a/src/ru/practicum/manager/InMemoryHistoryManager.java
+++ b/src/ru/practicum/manager/InMemoryHistoryManager.java
@@ -3,21 +3,76 @@ package ru.practicum.manager;
 import ru.practicum.model.Task;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class InMemoryHistoryManager implements HistoryManager {
-    private final List<Task> history = new ArrayList<>();
+    private final Map<Integer, Node> history = new HashMap<>();
+    private Node first;
+    private Node last;
+
+    private void linkLast(Task task) { //Добавляем элемент в конец списка и меняем ссылки last и first(при отсутствии first ранее)
+        Node newLast;
+        if (first == null) { // Если список пустой, то добавляется так
+            newLast = new Node(task, null, null);
+            first = newLast;
+        } else {
+            newLast = new Node(task, last, null);
+            last.next = newLast;
+        }
+        last = newLast;
+        history.put(task.getId(), last);
+    }
+
+    private List<Task> getTasks() {
+        List<Task> tasks = new ArrayList<>();
+        for (Node node : history.values()) {
+            tasks.add(node.task);
+        }
+        return tasks;
+    }
+
+    private void removeNode(Node node) {
+        /*
+        Здесь нужна проверка задачи на существование в истории, если мы просто создадим задачу и не будем к ней
+        обращаться, то она не попадет в историю, а при вызове метода removeTask в InMemoryHistoryManager мы удаляем
+        задачу из истории, для этого нужна проверка на Null
+         */
+        if (node == null) {
+            return;
+        }
+        if (first == last) { //Проверяем случай, когда весь список состоит из одного элемента
+            first = null;
+            last = null;
+        } else if (first == node) { //Проверяем, что первый элемент и переданный в метод ссылаются на один узел
+            first = first.next;
+            first.prev = null;
+        } else if (last == node) { //Аналогично проверяем последний
+            last = last.prev;
+            last.next = null;
+        } else {
+            node.prev.next = node.next;
+            node.next.prev = node.prev;
+        }
+        history.remove(node.task.getId());
+    }
 
     @Override
     public void add(Task task) {
-        if (history.size() == 10) {
-            history.removeFirst();
+        if (history.containsKey(task.getId())) {
+            removeNode(history.get(task.getId()));
         }
-        history.add(task);
+        linkLast(task);
     }
 
     @Override
     public List<Task> getHistory() {
-        return new ArrayList<>(history);
+        return getTasks();
+    }
+
+    @Override
+    public void remove(int id) {
+        removeNode(history.get(id));
     }
 }

--- a/src/ru/practicum/manager/InMemoryTaskManager.java
+++ b/src/ru/practicum/manager/InMemoryTaskManager.java
@@ -116,6 +116,7 @@ public class InMemoryTaskManager implements TaskManager {
             return;
         }
         tasks.remove(taskId);
+        historyManager.remove(taskId);
     }
 
     @Override
@@ -124,8 +125,9 @@ public class InMemoryTaskManager implements TaskManager {
             return;
         }
         int epicId = subTasks.get(subTaskId).getEpicId();
-        epics.get(epicId).removeSubTask(subTasks.get(subTaskId)); //Удаление сабтаски из мапы эпика
-        subTasks.remove(subTaskId); //Удаление сабтаски из общей мапы
+        epics.get(epicId).removeSubTask(subTasks.get(subTaskId)); //Удаление подзадачи из мапы эпика
+        subTasks.remove(subTaskId); //Удаление подзадачи из общей мапы
+        historyManager.remove(subTaskId);
     }
 
     @Override
@@ -135,8 +137,10 @@ public class InMemoryTaskManager implements TaskManager {
         }
         for (SubTask subTask : epics.get(epicId).getSubTasks()) { // Удаление всех подзадач удаляемого эпика из общего хранилища
             subTasks.remove(subTask.getId());
+            historyManager.remove(subTask.getId());
         }
         epics.remove(epicId);
+        historyManager.remove(epicId);
     }
 
     @Override
@@ -149,6 +153,9 @@ public class InMemoryTaskManager implements TaskManager {
 
     @Override
     public void deleteTasks() {
+        for (Task task : tasks.values()) {
+            historyManager.remove(task.getId());
+        }
         tasks.clear();
     }
 
@@ -157,11 +164,20 @@ public class InMemoryTaskManager implements TaskManager {
         for (Epic epic : epics.values()) {
             epic.removeAllSubtasks();
         }
+        for (SubTask subTask : subTasks.values()) {
+            historyManager.remove(subTask.getId());
+        }
         subTasks.clear();
     }
 
     @Override
     public void deleteEpics() {
+        for (Epic epic : epics.values()) {
+            historyManager.remove(epic.getId());
+        }
+        for (SubTask subTask : subTasks.values()) {
+            historyManager.remove(subTask.getId());
+        }
         epics.clear();
         subTasks.clear();
     }

--- a/src/ru/practicum/manager/Node.java
+++ b/src/ru/practicum/manager/Node.java
@@ -1,0 +1,15 @@
+package ru.practicum.manager;
+
+import ru.practicum.model.Task;
+
+class Node {
+    public Node prev;
+    public Node next;
+    public Task task;
+
+    public Node(Task task, Node prev, Node next) {
+        this.task = task;
+        this.prev = prev;
+        this.next = next;
+    }
+}

--- a/test/manager/InMemoryHistoryManagerTest.java
+++ b/test/manager/InMemoryHistoryManagerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import ru.practicum.manager.HistoryManager;
 import ru.practicum.manager.InMemoryHistoryManager;
+import ru.practicum.model.Status;
 import ru.practicum.model.Task;
 
 public class InMemoryHistoryManagerTest {
@@ -28,5 +29,28 @@ public class InMemoryHistoryManagerTest {
         Assertions.assertEquals(task.getName(), savedTask.getName(), "Имена задач не совпадают");
         Assertions.assertEquals(task.getDescription(), savedTask.getDescription(), "Описания задач не совпадают");
         Assertions.assertEquals(task.getStatus(), savedTask.getStatus(), "Статус задач не совпадает");
+    }
+
+    @Test
+    public void historyShouldNotContainRepeats() {
+        Task task1 = new Task("Название", "Описание", 1, Status.NEW);
+        Task task2 = new Task("Название1", "Описание1", 2, Status.NEW);
+        inMemoryHistoryManager.add(task1);
+        inMemoryHistoryManager.add(task2);
+        inMemoryHistoryManager.add(task1);
+
+        Assertions.assertEquals(2, inMemoryHistoryManager.getHistory().size(), "Длины списков не совпадают");
+    }
+
+    @Test
+    public void inMemoryHistoryManagerRemoveTask() {
+        Task task1 = new Task("Название", "Описание", 1, Status.NEW);
+        Task task2 = new Task("Название1", "Описание1", 2, Status.NEW);
+        inMemoryHistoryManager.add(task1);
+        inMemoryHistoryManager.add(task2);
+        inMemoryHistoryManager.remove(1);
+
+        Assertions.assertEquals(1, inMemoryHistoryManager.getHistory().size());
+        Assertions.assertEquals(task2, inMemoryHistoryManager.getHistory().getFirst());
     }
 }

--- a/test/manager/InMemoryTaskManagerTest.java
+++ b/test/manager/InMemoryTaskManagerTest.java
@@ -73,6 +73,10 @@ public class InMemoryTaskManagerTest {
         Assertions.assertEquals(subTask.getDescription(), savedSubTask.getDescription(), "Описания эпиков не совпадают");
         Assertions.assertEquals(Status.NEW, savedSubTask.getStatus(), "Статусы не совпадают");
         Assertions.assertEquals(subTaskId, savedSubTask.getId(), "id не совпадают");
+
+        SubTask subTask1 = new SubTask("Описание", "Название", 33);
+        int subTaskId1 = inMemoryTaskManager.createSubTask(subTask1);
+        Assertions.assertEquals(-1, subTaskId1);
     }
 
     @Test
@@ -85,5 +89,55 @@ public class InMemoryTaskManagerTest {
         Task savedTask = inMemoryTaskManager.getTaskById(taskId);
         Assertions.assertNotNull(savedTask, "Задача не сохранилась");
         Assertions.assertEquals(newTask, savedTask, "Обновление задачи не выполнилось");
+    }
+
+    @Test
+    public void getTaskShouldNotAddRepeatsToHistory() {
+        Task task = new Task("Название", "Описание");
+        int taskId = inMemoryTaskManager.createTask(task);
+
+        inMemoryTaskManager.getTaskById(taskId);
+        inMemoryTaskManager.getTaskById(taskId);
+        inMemoryTaskManager.getTasks();
+
+        Assertions.assertEquals(1,inMemoryTaskManager.getHistory().size());
+        Assertions.assertEquals(task, inMemoryTaskManager.getHistory().getFirst());
+    }
+
+    @Test
+    public void removeTaskShouldRemoveTaskFromHistory() {
+        Task task = new Task("Название", "Описание");
+        Task task1 = new Task("Название1", "Описание1");
+        int taskId = inMemoryTaskManager.createTask(task);
+        int taskId1 = inMemoryTaskManager.createTask(task1);
+
+        inMemoryTaskManager.getTaskById(taskId);
+        inMemoryTaskManager.getTaskById(taskId1);
+
+        Assertions.assertEquals(2, inMemoryTaskManager.getHistory().size());
+
+        inMemoryTaskManager.removeTask(taskId);
+
+        Assertions.assertEquals(1, inMemoryTaskManager.getHistory().size());
+        Assertions.assertEquals(task1, inMemoryTaskManager.getHistory().getFirst());
+    }
+
+    @Test
+    public void getSubTaskByEpic() {
+        Epic epic = new Epic("Описание", "Название");
+        int epicId = inMemoryTaskManager.createEpic(epic);
+
+        SubTask subTask = new SubTask("Описание", "Название",epicId);
+        SubTask subTask1 = new SubTask("Описание1", "Название1",epicId);
+        int subTaskId = inMemoryTaskManager.createSubTask(subTask);
+        int subTaskId1 = inMemoryTaskManager.createSubTask(subTask1);
+
+        Assertions.assertTrue(inMemoryTaskManager.getEpicById(epicId).getSubTasks().contains(subTask));
+        Assertions.assertTrue(inMemoryTaskManager.getEpicById(epicId).getSubTasks().contains(subTask1));
+
+        inMemoryTaskManager.removeSubTask(subTaskId);
+
+        Assertions.assertFalse(inMemoryTaskManager.getEpicById(epicId).getSubTasks().contains(subTask));
+        Assertions.assertTrue(inMemoryTaskManager.getEpicById(epicId).getSubTasks().contains(subTask1));
     }
 }


### PR DESCRIPTION
Добавлен двусвязный список в InMemoryHistoryManager для хранения истории обращений к задачам. Добавлены методы удаления и добавления в список задач.  При удалении задачи с помощью InMemoryTaskManager задача также удаляется из InMemoryHistoryManager.

Добавлены новые тесты. 